### PR TITLE
Seperate logger for components.

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -349,6 +349,12 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="MonriComponentsLogger" type="MonriPaymentsLogger">
+        <arguments>
+            <argument name="config" xsi:type="object">Monri\Payments\Gateway\Config\Components</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="MonriComponentsCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
         <arguments>
             <argument name="commands" xsi:type="array">
@@ -396,7 +402,7 @@
     <type name="Monri\Payments\Controller\Components\CreatePayment">
         <arguments>
             <argument name="commandManager" xsi:type="object">MonriComponentsCommandManager</argument>
-            <argument name="logger" xsi:type="object">MonriPaymentsLogger</argument>
+            <argument name="logger" xsi:type="object">MonriComponentsLogger</argument>
         </arguments>
     </type>
 


### PR DESCRIPTION
#20 Ready for testing.

@ivanviduka Additionally, commands are using MonriPaymentsVirtualLogger::critical() directly. Since it's critical error, it's fine that MonriPaymentsVirtualLogger writes log always (it is not aware of Monri setting), but test if it writes to our log file since we only implemented "debug" handler.
